### PR TITLE
Add reboot and shutdown system commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ onesibox-client/
 
 | Comando | Priorità | Descrizione |
 |---------|----------|-------------|
+| `reboot` | 1 (alta) | Riavvia il dispositivo |
+| `shutdown` | 1 (alta) | Spegne il dispositivo |
 | `join_zoom` | 1 (alta) | Partecipa a riunione Zoom |
 | `leave_zoom` | 1 (alta) | Lascia riunione Zoom |
 | `play_media` | 2 (media) | Riproduce video/audio da JW.org |

--- a/src/commands/handlers/system.js
+++ b/src/commands/handlers/system.js
@@ -1,0 +1,96 @@
+const { exec } = require('child_process');
+const logger = require('../../logging/logger');
+const { stateManager } = require('../../state/state-manager');
+
+/**
+ * Execute a system command with sudo.
+ * @param {string} command - The command to execute
+ * @returns {Promise<void>}
+ */
+function executeSystemCommand(command) {
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        logger.error('System command failed', { command, error: error.message, stderr });
+        reject(error);
+        return;
+      }
+      logger.info('System command executed', { command, stdout });
+      resolve();
+    });
+  });
+}
+
+/**
+ * Reboot the device.
+ * @param {object} command - The command object
+ * @param {object} browserController - The browser controller (unused but required by interface)
+ */
+async function reboot(command, browserController) {
+  const { delay = 0 } = command.payload || {};
+
+  logger.info('Reboot command received', { delay });
+
+  // Stop any current playback/meeting
+  const currentState = stateManager.getState();
+  if (currentState.status !== 'idle') {
+    logger.info('Stopping current activity before reboot');
+    await browserController.goToStandby();
+    stateManager.stopPlaying();
+  }
+
+  if (delay > 0) {
+    logger.info('Scheduling reboot', { delaySeconds: delay });
+    await executeSystemCommand(`sudo shutdown -r +${Math.ceil(delay / 60)}`);
+  } else {
+    logger.info('Executing immediate reboot');
+    // Small delay to allow acknowledgment to be sent
+    setTimeout(async () => {
+      try {
+        await executeSystemCommand('sudo reboot');
+      } catch (error) {
+        logger.error('Reboot execution failed', { error: error.message });
+      }
+    }, 1000);
+  }
+}
+
+/**
+ * Shutdown the device.
+ * @param {object} command - The command object
+ * @param {object} browserController - The browser controller (unused but required by interface)
+ */
+async function shutdown(command, browserController) {
+  const { delay = 0 } = command.payload || {};
+
+  logger.info('Shutdown command received', { delay });
+
+  // Stop any current playback/meeting
+  const currentState = stateManager.getState();
+  if (currentState.status !== 'idle') {
+    logger.info('Stopping current activity before shutdown');
+    await browserController.goToStandby();
+    stateManager.stopPlaying();
+  }
+
+  if (delay > 0) {
+    logger.info('Scheduling shutdown', { delaySeconds: delay });
+    await executeSystemCommand(`sudo shutdown -h +${Math.ceil(delay / 60)}`);
+  } else {
+    logger.info('Executing immediate shutdown');
+    // Small delay to allow acknowledgment to be sent
+    setTimeout(async () => {
+      try {
+        await executeSystemCommand('sudo shutdown -h now');
+      } catch (error) {
+        logger.error('Shutdown execution failed', { error: error.message });
+      }
+    }, 1000);
+  }
+}
+
+module.exports = {
+  reboot,
+  shutdown,
+  executeSystemCommand
+};

--- a/src/commands/manager.js
+++ b/src/commands/manager.js
@@ -4,12 +4,18 @@ const { validateCommand, getErrorCodeForValidation, getErrorCodeForCommandType, 
 const { stateManager, STATUS } = require('../state/state-manager');
 
 const COMMAND_PRIORITY = {
+  // System commands - highest priority
+  reboot: 1,
+  shutdown: 1,
+  // Video calls - high priority
   join_zoom: 1,
   leave_zoom: 1,
+  // Media playback - medium priority
   play_media: 2,
   stop_media: 2,
   pause_media: 2,
   resume_media: 2,
+  // Settings - low priority
   set_volume: 3
 };
 

--- a/src/commands/validator.js
+++ b/src/commands/validator.js
@@ -11,7 +11,8 @@ const ERROR_CODES = {
   ZOOM_HANDLER_FAILED: 'E007',
   VOLUME_HANDLER_FAILED: 'E008',
   COMMAND_EXPIRED: 'E009',
-  INVALID_PAYLOAD: 'E010'
+  INVALID_PAYLOAD: 'E010',
+  SYSTEM_HANDLER_FAILED: 'E011'
 };
 
 /**
@@ -47,7 +48,9 @@ const COMMAND_TYPES = [
   'resume_media',
   'set_volume',
   'join_zoom',
-  'leave_zoom'
+  'leave_zoom',
+  'reboot',
+  'shutdown'
 ];
 
 /**
@@ -241,6 +244,19 @@ function validateCommand(command) {
         errors.push('join_zoom meeting_url must be a valid Zoom URL');
       }
       break;
+
+    case 'reboot':
+    case 'shutdown':
+      // Optional delay parameter validation
+      if (command.payload?.delay !== undefined) {
+        if (typeof command.payload.delay !== 'number' ||
+            !Number.isFinite(command.payload.delay) ||
+            command.payload.delay < 0 ||
+            command.payload.delay > 3600) {
+          errors.push(`${command.type} delay must be 0-3600 seconds`);
+        }
+      }
+      break;
   }
 
   if (errors.length > 0) {
@@ -290,6 +306,9 @@ function getErrorCodeForCommandType(commandType) {
       return ERROR_CODES.ZOOM_HANDLER_FAILED;
     case 'set_volume':
       return ERROR_CODES.VOLUME_HANDLER_FAILED;
+    case 'reboot':
+    case 'shutdown':
+      return ERROR_CODES.SYSTEM_HANDLER_FAILED;
     default:
       return ERROR_CODES.INVALID_COMMAND_STRUCTURE;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -146,16 +146,26 @@ function registerHandlers() {
   const mediaHandler = require('./commands/handlers/media');
   const zoomHandler = require('./commands/handlers/zoom');
   const volumeHandler = require('./commands/handlers/volume');
+  const systemHandler = require('./commands/handlers/system');
 
   mediaHandler.setApiClient(apiClient);
 
+  // Media handlers
   commandManager.registerHandler('play_media', mediaHandler.playMedia);
   commandManager.registerHandler('stop_media', mediaHandler.stopMedia);
   commandManager.registerHandler('pause_media', mediaHandler.pauseMedia);
   commandManager.registerHandler('resume_media', mediaHandler.resumeMedia);
+
+  // Zoom handlers
   commandManager.registerHandler('join_zoom', zoomHandler.joinZoom);
   commandManager.registerHandler('leave_zoom', zoomHandler.leaveZoom);
+
+  // Volume handler
   commandManager.registerHandler('set_volume', volumeHandler.setVolume);
+
+  // System handlers
+  commandManager.registerHandler('reboot', systemHandler.reboot);
+  commandManager.registerHandler('shutdown', systemHandler.shutdown);
 }
 
 async function shutdown(signal) {

--- a/tests/unit/commands/system.test.js
+++ b/tests/unit/commands/system.test.js
@@ -1,0 +1,151 @@
+const { reboot, shutdown, executeSystemCommand } = require('../../../src/commands/handlers/system');
+
+// Mock dependencies
+jest.mock('../../../src/logging/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn()
+}));
+
+jest.mock('../../../src/state/state-manager', () => ({
+  stateManager: {
+    getState: jest.fn(() => ({ status: 'idle' })),
+    stopPlaying: jest.fn()
+  },
+  STATUS: {
+    IDLE: 'idle',
+    PLAYING: 'playing',
+    CALLING: 'calling'
+  }
+}));
+
+jest.mock('child_process', () => ({
+  exec: jest.fn((cmd, callback) => {
+    // Simulate successful command execution
+    callback(null, 'success', '');
+  })
+}));
+
+describe('System Handler', () => {
+  let mockBrowserController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    mockBrowserController = {
+      goToStandby: jest.fn().mockResolvedValue()
+    };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('reboot', () => {
+    it('should execute reboot command', async () => {
+      const command = {
+        id: '123',
+        type: 'reboot',
+        payload: {}
+      };
+
+      await reboot(command, mockBrowserController);
+
+      // Fast-forward the setTimeout
+      jest.advanceTimersByTime(1000);
+
+      const { exec } = require('child_process');
+      expect(exec).toHaveBeenCalledWith(
+        'sudo reboot',
+        expect.any(Function)
+      );
+    });
+
+    it('should schedule delayed reboot', async () => {
+      const command = {
+        id: '123',
+        type: 'reboot',
+        payload: { delay: 120 }
+      };
+
+      await reboot(command, mockBrowserController);
+
+      const { exec } = require('child_process');
+      expect(exec).toHaveBeenCalledWith(
+        'sudo shutdown -r +2',
+        expect.any(Function)
+      );
+    });
+
+    it('should stop current playback before reboot', async () => {
+      const { stateManager } = require('../../../src/state/state-manager');
+      stateManager.getState.mockReturnValue({ status: 'playing' });
+
+      const command = {
+        id: '123',
+        type: 'reboot',
+        payload: {}
+      };
+
+      await reboot(command, mockBrowserController);
+
+      expect(mockBrowserController.goToStandby).toHaveBeenCalled();
+      expect(stateManager.stopPlaying).toHaveBeenCalled();
+    });
+  });
+
+  describe('shutdown', () => {
+    it('should execute shutdown command', async () => {
+      const command = {
+        id: '123',
+        type: 'shutdown',
+        payload: {}
+      };
+
+      await shutdown(command, mockBrowserController);
+
+      // Fast-forward the setTimeout
+      jest.advanceTimersByTime(1000);
+
+      const { exec } = require('child_process');
+      expect(exec).toHaveBeenCalledWith(
+        'sudo shutdown -h now',
+        expect.any(Function)
+      );
+    });
+
+    it('should schedule delayed shutdown', async () => {
+      const command = {
+        id: '123',
+        type: 'shutdown',
+        payload: { delay: 300 }
+      };
+
+      await shutdown(command, mockBrowserController);
+
+      const { exec } = require('child_process');
+      expect(exec).toHaveBeenCalledWith(
+        'sudo shutdown -h +5',
+        expect.any(Function)
+      );
+    });
+
+    it('should stop current playback before shutdown', async () => {
+      const { stateManager } = require('../../../src/state/state-manager');
+      stateManager.getState.mockReturnValue({ status: 'playing' });
+
+      const command = {
+        id: '123',
+        type: 'shutdown',
+        payload: {}
+      };
+
+      await shutdown(command, mockBrowserController);
+
+      expect(mockBrowserController.goToStandby).toHaveBeenCalled();
+      expect(stateManager.stopPlaying).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/commands/validator.test.js
+++ b/tests/unit/commands/validator.test.js
@@ -109,5 +109,51 @@ describe('Command Validator', () => {
       expect(result.valid).toBe(false);
       expect(result.errors).toContain('Command has expired');
     });
+
+    it('should validate reboot command', () => {
+      const valid = validateCommand({
+        id: '123',
+        type: 'reboot',
+        payload: {}
+      });
+      expect(valid.valid).toBe(true);
+
+      const withDelay = validateCommand({
+        id: '123',
+        type: 'reboot',
+        payload: { delay: 60 }
+      });
+      expect(withDelay.valid).toBe(true);
+
+      const invalidDelay = validateCommand({
+        id: '123',
+        type: 'reboot',
+        payload: { delay: 5000 }
+      });
+      expect(invalidDelay.valid).toBe(false);
+    });
+
+    it('should validate shutdown command', () => {
+      const valid = validateCommand({
+        id: '123',
+        type: 'shutdown',
+        payload: {}
+      });
+      expect(valid.valid).toBe(true);
+
+      const withDelay = validateCommand({
+        id: '123',
+        type: 'shutdown',
+        payload: { delay: 120 }
+      });
+      expect(withDelay.valid).toBe(true);
+
+      const invalidDelay = validateCommand({
+        id: '123',
+        type: 'shutdown',
+        payload: { delay: -10 }
+      });
+      expect(invalidDelay.valid).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add system command handler (`system.js`) with `reboot()` and `shutdown()` functions
- Support optional `delay` parameter (0-3600 seconds) for scheduled operations
- Stop current playback/meeting before executing system commands
- Add high priority (1) for system commands in command manager
- Update validator to accept `reboot` and `shutdown` command types
- Add `SYSTEM_HANDLER_FAILED` error code for error reporting

## Changes
- `src/commands/handlers/system.js` - New handler with reboot/shutdown
- `src/commands/manager.js` - Added command priorities
- `src/commands/validator.js` - Added validation for new commands
- `src/main.js` - Register new handlers
- `README.md` - Document new commands

## Test plan
- [x] Unit tests for reboot command (immediate and delayed)
- [x] Unit tests for shutdown command (immediate and delayed)
- [x] Tests verify playback stops before system commands
- [x] Validator tests for command validation
- [x] All 41 tests pass