### PR TITLE
Increase update check frequency to 5 minutes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -324,9 +324,9 @@ async function main() {
   stateManager.setConnectionStatus(CONNECTION_STATUS.CONNECTED);
   logger.info('OnesiBox ready');
 
-  // Start auto-updater (checks every 30 minutes by default)
+  // Start auto-updater (checks every 5 minutes by default)
   autoUpdater = new AutoUpdater({
-    checkIntervalSeconds: config.update_check_interval_seconds || 30 * 60
+    checkIntervalSeconds: config.update_check_interval_seconds || 5 * 60
   });
   autoUpdater.start();
 

--- a/src/update/auto-updater.js
+++ b/src/update/auto-updater.js
@@ -6,8 +6,8 @@ const logger = require('../logging/logger');
 
 const execFileAsync = promisify(execFile);
 
-// Default check interval: 30 minutes
-const DEFAULT_CHECK_INTERVAL_SECONDS = 30 * 60;
+// Default check interval: 5 minutes
+const DEFAULT_CHECK_INTERVAL_SECONDS = 5 * 60;
 const REPO_URL = 'git@github.com:onesiphorus-team/OnesiBox.git';
 const PROJECT_ROOT = path.join(__dirname, '../..');
 


### PR DESCRIPTION
## Summary
Reduce the default auto-update check interval from 30 minutes to 5 minutes for faster deployment of updates to devices.

## Changes
- `src/update/auto-updater.js`: Changed `DEFAULT_CHECK_INTERVAL_SECONDS` from `30 * 60` to `5 * 60`
- `src/main.js`: Updated fallback value from `30 * 60` to `5 * 60`

## Test plan
- [ ] Verify auto-updater checks for updates every 5 minutes
- [ ] Confirm updates are applied correctly when new tag is available