### PR TITLE
Add enhanced diagnostics to heartbeat and restart_service command

### DIFF
--- a/src/commands/handlers/service.js
+++ b/src/commands/handlers/service.js
@@ -1,0 +1,57 @@
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const logger = require('../../logging/logger');
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Restart the OnesiBox systemd service.
+ *
+ * This command is typically used by administrators to remotely restart
+ * the OnesiBox application without a full system reboot.
+ *
+ * @param {object} command - The command object
+ * @param {object} _browserController - Browser controller (unused)
+ * @returns {Promise<object>} Result with status and message
+ */
+async function restartService(command, _browserController) {
+  logger.info('Restarting OnesiBox service', { commandId: command.id });
+
+  try {
+    // Execute systemctl restart command
+    // This will cause the current process to be terminated by systemd
+    // and a new instance will be started
+    await execFileAsync('sudo', ['systemctl', 'restart', 'onesibox'], {
+      timeout: 30000 // 30 second timeout
+    });
+
+    // This code will likely not execute because the process will be killed
+    // by systemd, but we return a response just in case
+    return {
+      success: true,
+      message: 'Service restart initiated'
+    };
+  } catch (error) {
+    // If we get here, the restart command failed
+    logger.error('Failed to restart OnesiBox service', {
+      commandId: command.id,
+      error: error.message,
+      code: error.code
+    });
+
+    // Provide helpful error message
+    let message = `Failed to restart service: ${error.message}`;
+    if (error.code === 'ENOENT') {
+      message = 'systemctl command not found - is systemd available?';
+    } else if (error.message.includes('permission denied') ||
+               error.message.includes('not permitted')) {
+      message = 'Permission denied - ensure sudo is configured for onesibox user';
+    }
+
+    throw new Error(message);
+  }
+}
+
+module.exports = {
+  restartService
+};

--- a/src/commands/manager.js
+++ b/src/commands/manager.js
@@ -7,6 +7,7 @@ const COMMAND_PRIORITY = {
   // System commands - highest priority
   reboot: 1,
   shutdown: 1,
+  restart_service: 1,
   // Video calls - high priority
   join_zoom: 1,
   leave_zoom: 1,

--- a/src/commands/validator.js
+++ b/src/commands/validator.js
@@ -13,7 +13,8 @@ const ERROR_CODES = {
   COMMAND_EXPIRED: 'E009',
   INVALID_PAYLOAD: 'E010',
   SYSTEM_HANDLER_FAILED: 'E011',
-  DIAGNOSTICS_HANDLER_FAILED: 'E012'
+  DIAGNOSTICS_HANDLER_FAILED: 'E012',
+  SERVICE_HANDLER_FAILED: 'E013'
 };
 
 /**
@@ -52,6 +53,7 @@ const COMMAND_TYPES = [
   'leave_zoom',
   'reboot',
   'shutdown',
+  'restart_service',
   'get_system_info',
   'get_logs'
 ];
@@ -274,6 +276,7 @@ function validateCommand(command) {
       break;
 
     case 'get_system_info':
+    case 'restart_service':
       // No payload required
       break;
   }
@@ -328,6 +331,8 @@ function getErrorCodeForCommandType(commandType) {
     case 'reboot':
     case 'shutdown':
       return ERROR_CODES.SYSTEM_HANDLER_FAILED;
+    case 'restart_service':
+      return ERROR_CODES.SERVICE_HANDLER_FAILED;
     case 'get_system_info':
     case 'get_logs':
       return ERROR_CODES.DIAGNOSTICS_HANDLER_FAILED;


### PR DESCRIPTION
## Summary
- Extended heartbeat payload with detailed network info (type, interface, IP, netmask, gateway, MAC, DNS)
- Extended heartbeat with WiFi details (SSID, signal dBm/percent, channel, frequency, security)
- Extended heartbeat with detailed memory breakdown (total, used, free, available, buffers, cached)
- Added `app_version` to heartbeat (from git tag or package.json)
- Added `restart_service` command handler that executes `sudo systemctl restart onesibox`

## Test plan
- [x] All 102 unit tests pass
- [x] ESLint passes
- [ ] Test heartbeat sends extended network/memory data
- [ ] Test restart_service command restarts the service