### PR TITLE
Fix installation script URLs and add default server

### DIFF
--- a/docs/manuale-installazione.md
+++ b/docs/manuale-installazione.md
@@ -242,12 +242,12 @@ ssh pi@INDIRIZZO_IP
 Esegui questo comando per scaricare e avviare l'installatore:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/onesiphorus-team/onesibox-client/main/install.sh | sudo bash
+curl -sSL https://raw.githubusercontent.com/onesiphorus-team/OnesiBox/main/install.sh | sudo bash
 ```
 
 > 💡 Se il comando sopra non funziona, prova:
 > ```bash
-> wget -qO- https://raw.githubusercontent.com/onesiphorus-team/onesibox-client/main/install.sh | sudo bash
+> wget -qO- https://raw.githubusercontent.com/onesiphorus-team/OnesiBox/main/install.sh | sudo bash
 > ```
 
 ### 5.3 Segui la procedura guidata
@@ -293,15 +293,15 @@ L'installatore verificherà automaticamente che tutto sia a posto.
 ```
 2. URL del Server Onesiforo
    L'indirizzo del server dove si trova il pannello di controllo.
-   Esempio: https://onesiforo.tuodominio.it
-   URL: █
+   Premi Invio per usare il server predefinito: https://onesiforo.a80.it
+   URL [https://onesiforo.a80.it]: █
 ```
 
 **Cosa inserire:** L'indirizzo web del pannello Onesiforo.
 
-**Esempio:** `https://onesiforo.example.com`
+**Default:** Premi Invio per usare `https://onesiforo.a80.it` (server ufficiale)
 
-> ⚠️ Inserisci l'URL completo, incluso `https://`
+**Altro server:** Inserisci l'URL completo, incluso `https://`
 
 ---
 
@@ -766,7 +766,7 @@ Se hai problemi non risolti da questo manuale:
 
 1. **Controlla i log** per messaggi di errore specifici
 2. **Consulta la documentazione** nella cartella `/opt/onesibox/docs/`
-3. **Apri una issue** su GitHub: https://github.com/onesiphorus-team/onesibox-client/issues
+3. **Apri una issue** su GitHub: https://github.com/onesiphorus-team/OnesiBox/issues
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 # su un Raspberry Pi con Raspberry Pi OS (Bookworm 64-bit)
 #
 # Utilizzo:
-#   curl -sSL https://raw.githubusercontent.com/onesiphorus-team/onesibox-client/main/install.sh | sudo bash
+#   curl -sSL https://raw.githubusercontent.com/onesiphorus-team/OnesiBox/main/install.sh | sudo bash
 #   oppure:
 #   sudo ./install.sh
 # ============================================================================
@@ -27,7 +27,8 @@ INSTALL_DIR="/opt/onesibox"
 LOG_DIR="/var/log/onesibox"
 SERVICE_USER="onesibox"
 CONFIG_FILE="$INSTALL_DIR/config/config.json"
-REPO_URL="https://github.com/onesiphorus-team/onesibox-client.git"
+REPO_URL="https://github.com/onesiphorus-team/OnesiBox.git"
+DEFAULT_SERVER_URL="https://onesiforo.a80.it"
 
 # ============================================================================
 # Funzioni di utilità
@@ -204,9 +205,10 @@ collect_configuration() {
     # URL Server
     echo -e "${BOLD}2. URL del Server Onesiforo${NC}"
     echo -e "   ${YELLOW}L'indirizzo del server dove si trova il pannello di controllo.${NC}"
-    echo -e "   ${YELLOW}Esempio: https://onesiforo.tuodominio.it${NC}"
+    echo -e "   ${YELLOW}Premi Invio per usare il server predefinito: $DEFAULT_SERVER_URL${NC}"
     while true; do
-        read -r -p "   URL: " SERVER_URL
+        read -r -p "   URL [$DEFAULT_SERVER_URL]: " SERVER_URL
+        SERVER_URL=${SERVER_URL:-$DEFAULT_SERVER_URL}
         SERVER_URL="${SERVER_URL%/}"  # Rimuovi trailing slash
 
         if [ -z "$SERVER_URL" ]; then
@@ -643,7 +645,7 @@ print_summary() {
 
     echo -e "\n${BOLD}Supporto:${NC}"
     echo -e "  • Documentazione: ${CYAN}$INSTALL_DIR/docs/${NC}"
-    echo -e "  • Issues: ${CYAN}https://github.com/onesiphorus-team/onesibox-client/issues${NC}"
+    echo -e "  • Issues: ${CYAN}https://github.com/onesiphorus-team/OnesiBox/issues${NC}"
 
     echo -e "\n"
 }


### PR DESCRIPTION
## Summary
- Correct repository URL from `onesibox-client` to `OnesiBox`
- Add `https://onesiforo.a80.it` as default server URL (user can press Enter to accept)
- Update installation manual to reflect the default server option
- Fix GitHub Issues URL in summary output

## Test plan
- [ ] Verify `curl -sSL https://raw.githubusercontent.com/onesiphorus-team/OnesiBox/main/install.sh | bash -n` passes syntax check
- [ ] Test installation on a Raspberry Pi with default server URL