### PR TITLE
Add auto-update system with versioned migrations

### DIFF
--- a/scripts/cron-update.sh
+++ b/scripts/cron-update.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Wrapper script for cron-based auto-updates
+# Adds random delay to avoid all devices updating simultaneously
+#
+# Install in crontab:
+#   0 3 * * * /opt/onesibox/app/scripts/cron-update.sh
+#
+# This will check for updates every night at 3 AM (with random delay 0-30 min)
+#
+
+# Random delay (0-1800 seconds = 0-30 minutes)
+# Prevents all devices from hitting the git server at the same time
+DELAY=$((RANDOM % 1800))
+sleep $DELAY
+
+# Run update in cron mode (silent, no colors)
+/opt/onesibox/update.sh --cron

--- a/src/browser/controller.js
+++ b/src/browser/controller.js
@@ -85,7 +85,11 @@ class BrowserController {
       '--no-first-run',
       '--autoplay-policy=no-user-gesture-required',
       '--disable-session-crashed-bubble',
-      '--disable-features=TranslateUI',
+      // Disable translation popup completely
+      '--disable-features=TranslateUI,Translate',
+      '--disable-translate',
+      '--lang=it',
+      // Disable update checks
       '--check-for-update-interval=31536000',
       '--disable-component-update',
       '--disable-background-networking',
@@ -93,6 +97,10 @@ class BrowserController {
       '--disable-default-apps',
       '--start-fullscreen',
       '--no-sandbox',
+      // Camera and microphone permissions (for Zoom)
+      '--use-fake-ui-for-media-stream',
+      '--enable-usermedia-screen-capturing',
+      '--auto-accept-camera-and-microphone-capture',
     ];
 
     if (isWayland) {
@@ -138,6 +146,10 @@ class BrowserController {
       ignoreDefaultArgs: ['--enable-automation'],
       viewport: null,
       ignoreHTTPSErrors: true,
+      // Grant all permissions for camera, microphone, notifications
+      permissions: ['camera', 'microphone', 'notifications', 'geolocation'],
+      // Disable translation
+      locale: 'it-IT',
     };
 
     // Use system Chromium if available for codec support

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+#
+# OnesiBox Auto-Update Script
+# Pulls latest code and runs versioned migrations
+#
+# Usage:
+#   ./update.sh           # Interactive mode
+#   ./update.sh --cron    # Silent mode for cron jobs
+#
+set -e
+
+# Configuration
+INSTALL_DIR="/opt/onesibox"
+REPO_DIR="${INSTALL_DIR}"
+STATE_FILE="${INSTALL_DIR}/data/.update-state"
+LOG_FILE="${INSTALL_DIR}/logs/update.log"
+LOCK_FILE="/tmp/onesibox-update.lock"
+SERVICE_NAME="onesibox"
+
+# Colors (disabled in cron mode)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Parse arguments
+CRON_MODE=false
+if [[ "$1" == "--cron" ]]; then
+    CRON_MODE=true
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+fi
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+log() {
+    local level="$1"
+    local message="$2"
+    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+    # Ensure log directory exists
+    mkdir -p "$(dirname "${LOG_FILE}")" 2>/dev/null || true
+
+    # Always log to file
+    echo "[${timestamp}] [${level}] ${message}" >> "${LOG_FILE}"
+
+    # Print to console unless in cron mode
+    if [[ "$CRON_MODE" == "false" ]]; then
+        case "$level" in
+            INFO)  echo -e "${GREEN}[INFO]${NC} ${message}" ;;
+            WARN)  echo -e "${YELLOW}[WARN]${NC} ${message}" ;;
+            ERROR) echo -e "${RED}[ERROR]${NC} ${message}" ;;
+            *)     echo "[${level}] ${message}" ;;
+        esac
+    fi
+}
+
+cleanup() {
+    rm -f "${LOCK_FILE}"
+}
+
+run_pending_migrations() {
+    local migrations_dir="${REPO_DIR}/updates"
+
+    if [[ ! -d "${migrations_dir}" ]]; then
+        log "INFO" "No migrations directory found"
+        return 0
+    fi
+
+    # Ensure state directory exists
+    mkdir -p "$(dirname "${STATE_FILE}")" 2>/dev/null || true
+
+    # Load executed migrations
+    local executed=()
+    if [[ -f "${STATE_FILE}" ]]; then
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && executed+=("$line")
+        done < "${STATE_FILE}"
+    fi
+
+    # Find and run new migrations (sorted alphabetically)
+    local has_new=false
+    for migration in $(find "${migrations_dir}" -maxdepth 1 -name "*.sh" -type f | sort); do
+        [[ -f "$migration" ]] || continue
+
+        local name=$(basename "$migration")
+
+        # Skip README
+        [[ "$name" == "README.md" ]] && continue
+
+        # Skip if already executed
+        local already_executed=false
+        for exec in "${executed[@]}"; do
+            if [[ "$exec" == "$name" ]]; then
+                already_executed=true
+                break
+            fi
+        done
+
+        if [[ "$already_executed" == "true" ]]; then
+            continue
+        fi
+
+        has_new=true
+        log "INFO" "Running migration: ${name}"
+
+        # Execute migration
+        if bash "$migration" 2>&1 | while IFS= read -r line; do log "INFO" "  ${line}"; done; then
+            # Mark as executed
+            echo "$name" >> "${STATE_FILE}"
+            log "INFO" "Migration completed: ${name}"
+        else
+            log "ERROR" "Migration failed: ${name}"
+            # Don't continue with other migrations if one fails
+            return 1
+        fi
+    done
+
+    if [[ "$has_new" == "false" ]]; then
+        log "INFO" "No new migrations to run"
+    fi
+}
+
+restart_service() {
+    log "INFO" "Restarting ${SERVICE_NAME} service..."
+
+    if command -v systemctl &> /dev/null; then
+        if systemctl is-active --quiet "${SERVICE_NAME}" 2>/dev/null; then
+            if systemctl restart "${SERVICE_NAME}" 2>/dev/null; then
+                log "INFO" "Service restarted successfully"
+            else
+                log "WARN" "Failed to restart service (run as root?)"
+            fi
+        else
+            log "INFO" "Service not running, starting..."
+            systemctl start "${SERVICE_NAME}" 2>/dev/null || \
+                log "WARN" "Failed to start service"
+        fi
+    else
+        log "WARN" "systemctl not found, please restart manually"
+    fi
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+main() {
+    trap cleanup EXIT
+
+    # Check if already running
+    if [[ -f "${LOCK_FILE}" ]]; then
+        pid=$(cat "${LOCK_FILE}" 2>/dev/null || echo "")
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            log "WARN" "Update already in progress (PID: ${pid})"
+            exit 0
+        fi
+    fi
+    echo $$ > "${LOCK_FILE}"
+
+    # Create directories if needed
+    mkdir -p "$(dirname "${LOG_FILE}")" 2>/dev/null || true
+    mkdir -p "$(dirname "${STATE_FILE}")" 2>/dev/null || true
+
+    log "INFO" "=== OnesiBox Update Started ==="
+
+    # Check if running as root (required for service restart)
+    if [[ $EUID -ne 0 ]]; then
+        log "WARN" "Running without root privileges. Service restart may fail."
+    fi
+
+    # Navigate to repo
+    if [[ ! -d "${REPO_DIR}" ]]; then
+        log "ERROR" "Repository not found at ${REPO_DIR}"
+        exit 1
+    fi
+    cd "${REPO_DIR}"
+
+    # Check if this is a git repo
+    if [[ ! -d ".git" ]]; then
+        log "ERROR" "Not a git repository: ${REPO_DIR}"
+        exit 1
+    fi
+
+    # Get current version before pull
+    OLD_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+    OLD_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")
+
+    log "INFO" "Current version: ${OLD_VERSION} (${OLD_COMMIT:0:7})"
+
+    # Fetch and check for updates
+    log "INFO" "Checking for updates..."
+    if ! git fetch origin main --quiet 2>/dev/null; then
+        log "ERROR" "Failed to fetch from remote"
+        exit 1
+    fi
+
+    LOCAL=$(git rev-parse HEAD)
+    REMOTE=$(git rev-parse origin/main 2>/dev/null || git rev-parse origin/master 2>/dev/null)
+
+    if [[ "$LOCAL" == "$REMOTE" ]]; then
+        log "INFO" "Already up to date"
+
+        # Still run pending migrations (in case previous update failed)
+        run_pending_migrations
+        log "INFO" "=== Update Check Complete ==="
+        exit 0
+    fi
+
+    # Pull updates
+    log "INFO" "Downloading updates..."
+    git reset --hard origin/main --quiet 2>/dev/null || git reset --hard origin/master --quiet
+    git pull origin main --quiet 2>/dev/null || git pull origin master --quiet
+
+    NEW_COMMIT=$(git rev-parse HEAD)
+    NEW_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "unknown")
+
+    log "INFO" "Updated to version: ${NEW_VERSION} (${NEW_COMMIT:0:7})"
+
+    # Check if package.json changed (need npm install)
+    if git diff --name-only "${OLD_COMMIT}" "${NEW_COMMIT}" 2>/dev/null | grep -q "package.json"; then
+        log "INFO" "Dependencies changed, running npm install..."
+        npm install --production --silent 2>/dev/null || npm install --production
+    fi
+
+    # Run migrations
+    run_pending_migrations
+
+    # Restart service
+    restart_service
+
+    log "INFO" "=== Update Complete ==="
+}
+
+# Run main
+main "$@"

--- a/updates/001-reset-browser-profile.sh
+++ b/updates/001-reset-browser-profile.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Migration 001: Reset browser profile
+# Clears Playwright profile to apply new camera/microphone permissions
+# and translation settings
+#
+
+PROFILE_DIR="/opt/onesibox/data/playwright-profile"
+
+if [[ -d "${PROFILE_DIR}" ]]; then
+    echo "Removing old browser profile to apply new permissions..."
+    rm -rf "${PROFILE_DIR}"
+    echo "Browser profile cleared"
+else
+    echo "No existing browser profile found"
+fi
+
+# Also clear chromium profile if using fallback mode
+CHROMIUM_PROFILE="/opt/onesibox/data/chromium"
+if [[ -d "${CHROMIUM_PROFILE}" ]]; then
+    echo "Removing old Chromium profile..."
+    rm -rf "${CHROMIUM_PROFILE}"
+    echo "Chromium profile cleared"
+fi
+
+echo "New profiles will be created on next browser start"

--- a/updates/README.md
+++ b/updates/README.md
@@ -1,0 +1,53 @@
+# OnesiBox Update Migrations
+
+Questa cartella contiene script di migrazione che vengono eseguiti automaticamente durante gli aggiornamenti.
+
+## Come funziona
+
+1. Lo script `update.sh` esegue `git pull`
+2. Cerca tutti i file `.sh` in questa cartella
+3. Esegue solo quelli che non sono stati ancora eseguiti (tracciati in `/opt/onesibox/data/.update-state`)
+4. Gli script vengono eseguiti in ordine alfabetico
+
+## Convenzioni di naming
+
+```
+NNN-descrizione-breve.sh
+```
+
+- `NNN`: Numero sequenziale a 3 cifre (001, 002, 003...)
+- `descrizione-breve`: Nome descrittivo con trattini
+
+## Creare una nuova migrazione
+
+1. Trova il prossimo numero disponibile
+2. Crea il file con il pattern corretto
+3. Rendi lo script idempotente (sicuro da eseguire più volte)
+4. Testa localmente prima di pushare
+
+## Esempio
+
+```bash
+#!/bin/bash
+#
+# Migration 002: Descrizione
+#
+
+echo "Eseguendo operazione..."
+# La tua logica qui
+echo "Completato"
+```
+
+## Best practices
+
+- Gli script devono essere idempotenti
+- Usa `echo` per loggare il progresso
+- Exit code 0 = successo, altri = fallimento
+- Non fare mai `exit 1` senza un buon motivo
+- Testa su un dispositivo di sviluppo prima
+
+## Migrazioni esistenti
+
+| # | Nome | Descrizione |
+|---|------|-------------|
+| 001 | reset-browser-profile | Pulisce il profilo browser per applicare nuovi permessi camera/mic |


### PR DESCRIPTION
## Summary

- Add `update.sh` script for manual and cron-based automatic updates
- Add versioned migrations system (`updates/` folder) for post-update operations
- Fix browser: disable translation popup, auto-enable camera/microphone for Zoom
- Configure auto-updates during installation (optional, runs nightly at 3 AM)

## Changes

### New files
| File | Description |
|------|-------------|
| `update.sh` | Main update script (git pull + migrations + service restart) |
| `scripts/cron-update.sh` | Cron wrapper with random delay (0-30 min) to avoid thundering herd |
| `updates/001-reset-browser-profile.sh` | First migration: clears browser profile to apply new permissions |
| `updates/README.md` | Documentation for creating new migrations |

### Modified files
| File | Change |
|------|--------|
| `install.sh` | Added `setup_auto_updates()` section with cron configuration |
| `src/browser/controller.js` | Added flags to disable translation and enable camera/mic permissions |

## How it works

```
cron (3 AM) → random delay → git pull → run new migrations → restart service
```

Migrations are tracked in `/opt/onesibox/data/.update-state` and only run once per device.

## Test plan

- [ ] Run `./update.sh` manually and verify it pulls updates correctly
- [ ] Verify migrations run only once (check `.update-state` file)
- [ ] Test cron mode: `./update.sh --cron` (silent output)
- [ ] Verify browser starts without translation popup
- [ ] Verify Zoom video calls work without permission prompts