### PR TITLE
Fix systemd service permissions for Wayland/Chromium

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -589,12 +589,13 @@ Environment=NODE_ENV=production
 Environment=DISPLAY=:0
 Environment=WAYLAND_DISPLAY=wayland-0
 Environment=XDG_RUNTIME_DIR=/run/user/$KIOSK_USER_UID
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$KIOSK_USER_UID/bus
 WorkingDirectory=$INSTALL_DIR
 
 # Sicurezza
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=$INSTALL_DIR $LOG_DIR $KIOSK_USER_HOME/.cache $KIOSK_USER_HOME/.config
+ReadWritePaths=$INSTALL_DIR $LOG_DIR $KIOSK_USER_HOME/.cache $KIOSK_USER_HOME/.config /run/user/$KIOSK_USER_UID
 PrivateTmp=true
 
 [Install]

--- a/updates/002-fix-systemd-permissions.sh
+++ b/updates/002-fix-systemd-permissions.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Migration 002: Fix systemd service permissions
+# Adds /run/user/UID to ReadWritePaths and DBUS_SESSION_BUS_ADDRESS
+# Required for Chromium to work properly with Wayland
+#
+
+SERVICE_FILE="/etc/systemd/system/onesibox.service"
+
+if [[ ! -f "${SERVICE_FILE}" ]]; then
+    echo "Service file not found, skipping"
+    exit 0
+fi
+
+# Get the kiosk user UID from the service file
+KIOSK_USER=$(grep "^User=" "${SERVICE_FILE}" | cut -d= -f2)
+if [[ -z "${KIOSK_USER}" ]]; then
+    echo "Could not determine kiosk user from service file"
+    exit 1
+fi
+
+KIOSK_USER_UID=$(id -u "${KIOSK_USER}" 2>/dev/null)
+if [[ -z "${KIOSK_USER_UID}" ]]; then
+    echo "Could not get UID for user ${KIOSK_USER}"
+    exit 1
+fi
+
+echo "Updating systemd service for user ${KIOSK_USER} (UID: ${KIOSK_USER_UID})"
+
+# Check if already fixed
+if grep -q "/run/user/${KIOSK_USER_UID}" "${SERVICE_FILE}"; then
+    echo "Service already has /run/user/${KIOSK_USER_UID} in ReadWritePaths"
+else
+    echo "Adding /run/user/${KIOSK_USER_UID} to ReadWritePaths..."
+    sed -i "s|ReadWritePaths=\(.*\)|ReadWritePaths=\1 /run/user/${KIOSK_USER_UID}|" "${SERVICE_FILE}"
+fi
+
+# Add DBUS_SESSION_BUS_ADDRESS if not present
+if grep -q "DBUS_SESSION_BUS_ADDRESS" "${SERVICE_FILE}"; then
+    echo "DBUS_SESSION_BUS_ADDRESS already configured"
+else
+    echo "Adding DBUS_SESSION_BUS_ADDRESS..."
+    sed -i "/Environment=XDG_RUNTIME_DIR/a Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${KIOSK_USER_UID}/bus" "${SERVICE_FILE}"
+fi
+
+# Reload systemd
+echo "Reloading systemd daemon..."
+systemctl daemon-reload
+
+echo "Systemd service updated successfully"

--- a/updates/README.md
+++ b/updates/README.md
@@ -51,3 +51,4 @@ echo "Completato"
 | # | Nome | Descrizione |
 |---|------|-------------|
 | 001 | reset-browser-profile | Pulisce il profilo browser per applicare nuovi permessi camera/mic |
+| 002 | fix-systemd-permissions | Aggiunge /run/user/UID e DBUS al servizio systemd per Wayland |


### PR DESCRIPTION
## Summary

Fixes the black screen issue on existing installations caused by Chromium crashing due to missing permissions in the systemd service.

## Problem

The systemd service had `ProtectSystem=strict` but was missing:
1. `/run/user/UID` in `ReadWritePaths` - Chromium/dconf needs to write here
2. `DBUS_SESSION_BUS_ADDRESS` environment variable - Required for D-Bus communication

This caused Chromium to crash immediately with errors:
```
dconf-CRITICAL: unable to create file '/run/user/1000/dconf/user': File system in sola lettura
Failed to connect to the bus: Could not parse server address
```

## Changes

### New migration: `updates/002-fix-systemd-permissions.sh`
- Automatically patches existing `/etc/systemd/system/onesibox.service`
- Adds `/run/user/UID` to `ReadWritePaths`
- Adds `DBUS_SESSION_BUS_ADDRESS` environment variable
- Runs `systemctl daemon-reload`

### Updated: `install.sh`
- New installations will have correct permissions from the start

## Test plan

- [ ] Run `sudo ./update.sh` on existing installation
- [ ] Verify migration 002 runs and patches the service file
- [ ] Verify Chromium starts correctly after service restart
- [ ] Verify new installation creates service with correct permissions