### PR TITLE
fix: use correct log file path in get_logs handler

### DIFF
--- a/src/commands/handlers/logs.js
+++ b/src/commands/handlers/logs.js
@@ -4,9 +4,12 @@ const logger = require('../../logging/logger');
 const { sanitizeLogContent } = require('../../logging/log-sanitizer');
 
 /**
- * Default log file path.
+ * Get today's log file path using the same naming pattern as winston-daily-rotate-file.
  */
-const DEFAULT_LOG_PATH = path.join(process.cwd(), 'logs', 'application.log');
+function getTodayLogPath() {
+  const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+  return path.join(process.cwd(), 'logs', `onesibox-${today}.log`);
+}
 
 /**
  * Maximum number of log lines that can be requested.
@@ -36,7 +39,7 @@ async function getLogs(command, _browserController) {
   });
 
   try {
-    const logPath = command.payload?.log_path || DEFAULT_LOG_PATH;
+    const logPath = command.payload?.log_path || getTodayLogPath();
 
     // Security check: only allow reading from logs directory
     const normalizedPath = path.normalize(logPath);


### PR DESCRIPTION
## Summary
- Fix `get_logs` command returning empty results because it looked for `logs/application.log`
- Actual log files are named `logs/onesibox-YYYY-MM-DD.log` (winston-daily-rotate-file pattern)
- Replaced static `DEFAULT_LOG_PATH` with `getTodayLogPath()` that generates the correct dated filename

## Context
When requesting logs from the Onesiforo dashboard, the OnesiBox received the command but returned `lines: []` because the file didn't exist.

## Test plan
- [ ] Send `get_logs` command from dashboard and verify logs are returned
- [ ] Verify security check still prevents path traversal