### PR TITLE
fix: use local timezone for log file date

### DIFF
--- a/src/commands/handlers/logs.js
+++ b/src/commands/handlers/logs.js
@@ -7,7 +7,8 @@ const { sanitizeLogContent } = require('../../logging/log-sanitizer');
  * Get today's log file path using the same naming pattern as winston-daily-rotate-file.
  */
 function getTodayLogPath() {
-  const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+  const now = new Date();
+  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
   return path.join(process.cwd(), 'logs', `onesibox-${today}.log`);
 }
 


### PR DESCRIPTION
## Summary
- `getTodayLogPath()` used `toISOString()` (UTC) but winston-daily-rotate-file uses local timezone (CET)
- After midnight CET the function looked for yesterday's (UTC) log file instead of today's
- Now uses `new Date()` with local getFullYear/getMonth/getDate to match winston's behavior

## Test plan
- [ ] Request logs from dashboard after midnight CET and verify correct file is found