### PR TITLE
fix(update): fetch tags so getAppVersion reports the current release

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -196,7 +196,9 @@ main() {
 
     # Fetch and check for updates
     log "INFO" "Checking for updates..."
-    if ! git fetch origin main --quiet 2>/dev/null; then
+    # --tags ensures release tags (used by getAppVersion → git describe) are synced;
+    # --force keeps tag refs aligned if they were moved upstream.
+    if ! git fetch origin main --tags --force --quiet 2>/dev/null; then
         log "ERROR" "Failed to fetch from remote"
         exit 1
     fi


### PR DESCRIPTION
## The bug

\`update.sh\` called \`git fetch origin main\` **without \`--tags\`**. New release tags never landed on the box filesystem, even after the commits were pulled.

The client's \`getAppVersion()\` in \`src/main.js\` uses \`git describe --tags --abbrev=0\` to report the running version to the dashboard. Without the new tag locally, \`describe\` falls back to the most recent tag ancestor — so after today's v0.8.0 release, the Rosa Iannascoli box kept reporting \`v0.7.7\` to the Onesiforo dashboard despite running the v0.8.0 code.

## Fix

Add \`--tags --force\` to the fetch command. This keeps tag refs aligned on every update cycle and resolves mismatches if a tag was ever moved upstream.

## Verification (on-box)

Reproduced on \`onesi-box-rosa\` (Raspberry Pi, Debian trixie):

\`\`\`
# Before
cd /opt/onesibox && git describe --tags --abbrev=0
v0.7.7   # wrong — working tree is at the v0.8.0 merge commit

# After applying the fetch fix
sudo git fetch --tags
git describe --tags --abbrev=0
v0.8.0   # correct
\`\`\`

After service restart the box correctly heartbeat-ed \`app_version: 0.8.0\` to the dashboard.

## Rollout plan

- [ ] Merge → cut v0.8.1 tag
- [ ] Boxes already on main but with stale local tags will self-heal at the next nightly cron (the new \`--tags\` fetch will pull the fresh tag set)