### PR TITLE
fix(update): log version from git tag to match client heartbeat

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -190,7 +190,10 @@ main() {
 
     # Get current version before pull
     OLD_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
-    OLD_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")
+    # Match the client's own getAppVersion() source so the log reports the
+    # same version the dashboard sees (git tag), falling back to package.json.
+    OLD_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)
+    OLD_VERSION=${OLD_VERSION:-$(node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")}
 
     log "INFO" "Current version: ${OLD_VERSION} (${OLD_COMMIT:0:7})"
 
@@ -221,7 +224,8 @@ main() {
     git pull origin main --quiet 2>/dev/null || git pull origin master --quiet
 
     NEW_COMMIT=$(git rev-parse HEAD)
-    NEW_VERSION=$(node -p "require('./package.json').version" 2>/dev/null || echo "unknown")
+    NEW_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)
+    NEW_VERSION=${NEW_VERSION:-$(node -p "require('./package.json').version" 2>/dev/null || echo "unknown")}
 
     log "INFO" "Updated to version: ${NEW_VERSION} (${NEW_COMMIT:0:7})"
 


### PR DESCRIPTION
## The bug

\`update.sh\` logs \"Current version:\" and \"Updated to version:\" by reading \`package.json\`. That file is pinned at \`1.0.0\` and doesn't track releases, so the log is misleading:

\`\`\`
[INFO] Current version: 1.0.0 (831fe6d)
[INFO] Already up to date
\`\`\`

Even though the box is actually on v0.8.1 (per the dashboard and \`git describe\`).

## Fix

Use \`git describe --tags --abbrev=0\` — same source the Node client's \`getAppVersion()\` uses — with \`package.json\` as a fallback only if git fails (shallow clone, detached HEAD, etc).

Now the log will read:
\`\`\`
[INFO] Current version: 0.8.1 (831fe6d)
\`\`\`

Cosmetic only, zero behavior change.