### PR TITLE
feat(logs): filter heartbeat lines from get_logs by default

### DIFF
--- a/src/commands/handlers/logs.js
+++ b/src/commands/handlers/logs.js
@@ -23,8 +23,23 @@ const MAX_LINES = 500;
 const DEFAULT_LINES = 100;
 
 /**
+ * Check whether a log line is a heartbeat record emitted by startHeartbeat().
+ * Heartbeats are JSON lines with message === 'Heartbeat sent'.
+ */
+function isHeartbeatLine(line) {
+  if (!line.includes('Heartbeat sent')) return false;
+  try {
+    return JSON.parse(line).message === 'Heartbeat sent';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Get the last N lines from the application log file.
  * Sanitizes sensitive data before returning.
+ * Heartbeat records are filtered out by default — set payload.include_heartbeats
+ * to true to keep them (useful for diagnosing missing heartbeats).
  *
  * @param {object} command - The command object
  * @param {object} _browserController - Browser controller (unused)
@@ -33,10 +48,12 @@ const DEFAULT_LINES = 100;
 async function getLogs(command, _browserController) {
   const requestedLines = command.payload?.lines || DEFAULT_LINES;
   const lines = Math.min(Math.max(1, requestedLines), MAX_LINES);
+  const includeHeartbeats = command.payload?.include_heartbeats === true;
 
   logger.info('Retrieving application logs', {
     commandId: command.id,
-    requestedLines: lines
+    requestedLines: lines,
+    includeHeartbeats
   });
 
   try {
@@ -68,8 +85,14 @@ async function getLogs(command, _browserController) {
     const content = await fs.readFile(logPath, 'utf-8');
     const allLines = content.split('\n').filter(line => line.trim());
 
+    // Filter heartbeats BEFORE slicing so that N lines of signal aren't drowned
+    // out by the heartbeat noise that dominates the tail of the file.
+    const candidateLines = includeHeartbeats
+      ? allLines
+      : allLines.filter(line => !isHeartbeatLine(line));
+
     // Get last N lines
-    const lastLines = allLines.slice(-lines);
+    const lastLines = candidateLines.slice(-lines);
 
     // Sanitize sensitive data
     const sanitizedLines = sanitizeLogContent(lastLines);
@@ -77,7 +100,8 @@ async function getLogs(command, _browserController) {
     logger.info('Logs retrieved successfully', {
       commandId: command.id,
       totalLines: allLines.length,
-      returnedLines: sanitizedLines.length
+      returnedLines: sanitizedLines.length,
+      heartbeatsFiltered: allLines.length - candidateLines.length
     });
 
     return {
@@ -85,6 +109,7 @@ async function getLogs(command, _browserController) {
       total_lines: allLines.length,
       requested_lines: lines,
       returned_lines: sanitizedLines.length,
+      heartbeats_filtered: allLines.length - candidateLines.length,
       log_file: path.basename(logPath),
       timestamp: new Date().toISOString()
     };

--- a/src/commands/validator.js
+++ b/src/commands/validator.js
@@ -345,6 +345,10 @@ function validateCommand(command) {
           errors.push('get_logs lines must be 1-500');
         }
       }
+      if (command.payload?.include_heartbeats !== undefined &&
+          typeof command.payload.include_heartbeats !== 'boolean') {
+        errors.push('get_logs include_heartbeats must be a boolean');
+      }
       break;
 
     case 'get_system_info':

--- a/tests/unit/commands/logs.test.js
+++ b/tests/unit/commands/logs.test.js
@@ -163,4 +163,103 @@ describe('Logs Handler', () => {
     });
   });
 
+  describe('Heartbeat filtering', () => {
+    const heartbeat = (ts) => JSON.stringify({
+      level: 'info',
+      message: 'Heartbeat sent',
+      service: 'onesibox',
+      status: 'idle',
+      timestamp: ts
+    });
+    const realLog = (msg) => JSON.stringify({
+      level: 'info',
+      message: msg,
+      service: 'onesibox'
+    });
+
+    it('filters out heartbeat lines by default', async () => {
+      const logContent = [
+        realLog('App started'),
+        heartbeat('2026-04-24T10:00:00Z'),
+        realLog('Command received'),
+        heartbeat('2026-04-24T10:00:30Z'),
+        realLog('Command completed')
+      ].join('\n');
+
+      fs.access.mockResolvedValue();
+      fs.readFile.mockResolvedValue(logContent);
+
+      const command = { id: '123', type: 'get_logs', payload: { lines: 10 } };
+      const result = await getLogs(command, mockBrowserController);
+
+      expect(result.returned_lines).toBe(3);
+      expect(result.total_lines).toBe(5);
+      expect(result.heartbeats_filtered).toBe(2);
+      expect(result.lines.every(line => !line.includes('Heartbeat sent'))).toBe(true);
+    });
+
+    it('includes heartbeats when include_heartbeats is true', async () => {
+      const logContent = [
+        realLog('App started'),
+        heartbeat('2026-04-24T10:00:00Z'),
+        realLog('Command received')
+      ].join('\n');
+
+      fs.access.mockResolvedValue();
+      fs.readFile.mockResolvedValue(logContent);
+
+      const command = {
+        id: '123',
+        type: 'get_logs',
+        payload: { lines: 10, include_heartbeats: true }
+      };
+      const result = await getLogs(command, mockBrowserController);
+
+      expect(result.returned_lines).toBe(3);
+      expect(result.heartbeats_filtered).toBe(0);
+      expect(result.lines.some(line => line.includes('Heartbeat sent'))).toBe(true);
+    });
+
+    it('filters heartbeats BEFORE slicing so requested N lines are all signal', async () => {
+      // 20 heartbeats tail-padding 2 real log lines: requesting 2 lines must
+      // return the 2 real lines, not 2 heartbeats.
+      const heartbeats = Array.from({ length: 20 }, (_, i) =>
+        heartbeat(`2026-04-24T10:00:${String(i).padStart(2, '0')}Z`)
+      );
+      const logContent = [
+        realLog('First real event'),
+        realLog('Second real event'),
+        ...heartbeats
+      ].join('\n');
+
+      fs.access.mockResolvedValue();
+      fs.readFile.mockResolvedValue(logContent);
+
+      const command = { id: '123', type: 'get_logs', payload: { lines: 2 } };
+      const result = await getLogs(command, mockBrowserController);
+
+      expect(result.returned_lines).toBe(2);
+      expect(result.lines[0]).toContain('First real event');
+      expect(result.lines[1]).toContain('Second real event');
+      expect(result.heartbeats_filtered).toBe(20);
+    });
+
+    it('treats non-JSON lines as non-heartbeats', async () => {
+      const logContent = [
+        'plain text without JSON',
+        'Heartbeat sent but not valid JSON',
+        realLog('App event')
+      ].join('\n');
+
+      fs.access.mockResolvedValue();
+      fs.readFile.mockResolvedValue(logContent);
+
+      const command = { id: '123', type: 'get_logs', payload: { lines: 10 } };
+      const result = await getLogs(command, mockBrowserController);
+
+      expect(result.returned_lines).toBe(3);
+      expect(result.heartbeats_filtered).toBe(0);
+    });
+  });
+
 });

--- a/tests/unit/commands/validator.test.js
+++ b/tests/unit/commands/validator.test.js
@@ -194,6 +194,30 @@ describe('Command Validator', () => {
       });
       expect(invalidDelay.valid).toBe(false);
     });
+
+    it('should validate get_logs include_heartbeats flag', () => {
+      const noFlag = validateCommand({
+        id: '123',
+        type: 'get_logs',
+        payload: { lines: 50 }
+      });
+      expect(noFlag.valid).toBe(true);
+
+      const asBool = validateCommand({
+        id: '123',
+        type: 'get_logs',
+        payload: { include_heartbeats: true }
+      });
+      expect(asBool.valid).toBe(true);
+
+      const asNonBool = validateCommand({
+        id: '123',
+        type: 'get_logs',
+        payload: { include_heartbeats: 'yes' }
+      });
+      expect(asNonBool.valid).toBe(false);
+      expect(asNonBool.errors.join(' ')).toMatch(/include_heartbeats/);
+    });
   });
 
   describe('validateCommand — play_stream_item', () => {


### PR DESCRIPTION
## Summary
- Heartbeat log lines (`message === 'Heartbeat sent'`) are now filtered out of `get_logs` responses by default — they dominated the tail of the log and drowned out real events when asking for the last N lines.
- Filtering happens **before** slicing so the N returned lines are all signal.
- New optional payload flag `include_heartbeats: true` keeps them when diagnosing missing heartbeats.
- Response now exposes `heartbeats_filtered` count.

## Test plan
- [x] `npm test -- --testPathPatterns="commands/(logs|validator)"` — 51/51 pass, including 4 new heartbeat-filter tests and 1 new validator test
- [ ] Manual: request `get_logs` from admin UI and confirm no heartbeats appear by default
- [ ] Manual: request with `include_heartbeats: true` and confirm heartbeats are returned