### PR TITLE
fix(update): install grim and webp on existing boxes via migration

### DIFF
--- a/updates/006-install-grim-webp.sh
+++ b/updates/006-install-grim-webp.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Migration 006: Install grim (Wayland screenshot) and webp (cwebp compressor)
+# Required for diagnostic screenshots feature (v0.10.0+).
+#
+# Idempotent: apt-get install is a no-op if packages are already present.
+#
+
+set -e
+
+echo "Installing grim and webp for diagnostic screenshots..."
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -qq
+apt-get install -y --no-install-recommends grim webp
+
+echo "Verifying binaries..."
+which grim && grim --help 2>&1 | head -1 || { echo "ERROR: grim not available after install"; exit 1; }
+which cwebp && cwebp -version 2>&1 | head -1 || { echo "ERROR: cwebp not available after install"; exit 1; }
+
+echo "Done"


### PR DESCRIPTION
## Summary

v0.10.0 introduced the diagnostic-screenshots feature which requires two Debian packages (\`grim\`, \`webp\`) on each box. These are added to \`install.sh\` for new installations, but **existing boxes that auto-update don't install them**: \`update.sh\` only runs \`npm install\`, not \`apt install\`.

Without this fix the scheduler lands on v0.10.0, \`grim\` is missing, the scheduler catches ENOENT, logs once, and auto-disables (graceful but silent failure — no screenshots sent).

## Fix

Added migration script \`updates/006-install-grim-webp.sh\`. \`update.sh\`'s \`run_pending_migrations\` function automatically picks it up and runs it once per box on the next auto-update, then records it in \`state\` to avoid re-running.

The script is idempotent: \`apt-get install\` on already-present packages is a no-op.

## Test plan
- [ ] On a staging box running v0.9.x, trigger auto-update
- [ ] Verify migration 006 runs in \`journalctl -u onesibox\` logs
- [ ] \`which grim && which cwebp\` returns paths
- [ ] Box starts sending screenshots to onesiforo server (visible in \`/admin/onesi-boxes/{id}/screenshots\`)