### PR TITLE
fix(diagnostics): use -- separator for cwebp stdin input

### DIFF
--- a/src/diagnostics/capture.js
+++ b/src/diagnostics/capture.js
@@ -15,7 +15,10 @@ function captureScreen({ quality = 75, timeoutMs = 8000 } = {}) {
 
     try {
       grim = spawn('grim', ['-t', 'ppm', '-'], { env });
-      cwebp = spawn('cwebp', ['-q', String(quality), '-o', '-', '-'], { env });
+      // The `--` separator is required: cwebp 1.5 refuses to treat a trailing
+      // bare `-` as the stdin input filename unless options are explicitly
+      // terminated. Without it: "Error! Unknown option '-'" and exit code 1.
+      cwebp = spawn('cwebp', ['-q', String(quality), '-o', '-', '--', '-'], { env });
     } catch (err) {
       return reject(new Error(`spawn failed: ${err.code || err.message}`));
     }


### PR DESCRIPTION
## Summary

Observed on production box \"Rosa Iannascoli\" running v0.10.1 + migration 006 (grim + webp 1.5.0 installed): the scheduler logged every 60s:

\`\`\`
screenshot: upload failed, dropping
err: cwebp exited with code 1: Error! Unknown option '-'
\`\`\`

## Root cause

cwebp 1.5 parses \`cwebp -q 75 -o - -\` and refuses to treat the trailing bare \`-\` as the stdin input filename — it sees it as an unknown option and exits with code 1.

## Fix

Add \`--\` to explicitly terminate option parsing before the stdin placeholder:

\`\`\`
cwebp -q 75 -o - -- -
\`\`\`

Verified working on the Rosa box: produces a valid 1920x1080 WebP, ~15KB.

## Test plan
- [ ] CI green (152 tests)
- [ ] After v0.10.2 deploy: verify journalctl/winston logs show no more \"cwebp exited with code 1\"
- [ ] Screenshots appear in \`/admin/onesi-boxes/{id}/screenshots\`